### PR TITLE
remove misplaced coma

### DIFF
--- a/overview/p12_lists/README.md
+++ b/overview/p12_lists/README.md
@@ -105,7 +105,7 @@ they default to ***-1*** and ***-1*** respectively.
 ['quux', 'corge']
 
 >>> # everything except the last two items
->>> a[:,-2]
+>>> a[:-2]
 ['foo', 'bar', 'baz', 'qux']
 ```
 ## List comprehensions


### PR DESCRIPTION
In part 12 of the Z2H,
There is a very small mistake in the README.md
Instead of a[:,2] it should say a[:-2] (without the comma)